### PR TITLE
Delete color for p sibling of h1 which matches background making text invisible

### DIFF
--- a/pipe.css
+++ b/pipe.css
@@ -189,7 +189,6 @@ h1 a, h2 a, h3 a, h4 a
 #content h1 + p {
     font-size: 18px;
     line-height: 30px;
-    color: #46483e;
     font-family: Georgia, FreeSerif, Times, serif;
 }
 


### PR DESCRIPTION

Fixes: #6 