### PR TITLE
Remove reference to a non-existing .css file in enide/index.html

### DIFF
--- a/enide/index.html
+++ b/enide/index.html
@@ -9,7 +9,6 @@ title: Nodeclipse, Enide
     <meta content="nodeclipse,Nodeclipse,node.js,eclipse pulgin,ide,node" name="keywords">
     <link type="image/x-icon" rel="icon" href="http://www.nodeclipse.org/favicon.ico">
     <link type="image/x-icon" rel="shortcut icon" href="http://www.nodeclipse.org/favicon.ico">
-    <link rel="stylesheet" href="http://www.nodeclipse.org/pipe.css">
 	<title>Nodeclipse - Enide: Eclipse Node.js IDE</title>
 	<style>
 		ul {


### PR DESCRIPTION
Fixes: #8